### PR TITLE
Fixed invalid equality check on image array in BioWriter

### DIFF
--- a/utils/polus-bfio-util/bfio/bfio.py
+++ b/utils/polus-bfio-util/bfio/bfio.py
@@ -974,7 +974,7 @@ class BioWriter():
             self._metadata.image(0).Name = file_path
             self._metadata.image().Pixels.channel_count = self._xyzct['C']
             self._metadata.image().Pixels.DimensionOrder = bioformats.omexml.DO_XYZCT
-        elif image != None:
+        elif image is not None:
             assert len(image.shape) == 5, "Image must be 5-dimensional (x,y,z,c,t)."
             x = X if X else image.shape[1]
             y = Y if Y else image.shape[0]


### PR DESCRIPTION
Currently, in BioWriter, if you pass in an image with no metadata, there is a check to ensure the `image` argument is not None. However, the comparison performed is an equality check (`!=`) rather than an identity check (`is not`). This results in a value error since a numpy array cannot be compared directly with a scalar in a logical. The typical error is as follows: 

`ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()` 

This PR fixes this bug.